### PR TITLE
Concurrent downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ python aebn_dl.py https://*.aebn.com/*/movies/*
 
 3. The script will download the movie and save it in the current working directory.
 
+## Usage for Concurrent Downloads
+You can use a `list.txt` file with multiple URL's (one per line) and pass it instead of a URL to the script, for example
+```
+python aebn_dl.py list.txt
+```
+It will download the videos in parallel with a default of 10 threads. The download queue will keep replenishing to the set maximum threads, until all the URL's are processed. You can change the threads with the `-t/--threads` argument.
+
+**Please don't abuse this feature, hammering the servers with high concurrent downloads might throttle the http connections, or possibly get your IP blocked. So use with caution and try to stay under the radar.**
+
 ## Running the Script with Different Arguments
 
 You can customize the behavior of the script by passing different arguments when running it. The available arguments are:
@@ -33,7 +42,7 @@ You can customize the behavior of the script by passing different arguments when
 | Argument | Description |
 | --- | --- |
 |`-h, --help`|Show this help message and exit|
-|`url`|The URL of the movie to download (required)|
+|`url` or `list.txt` file|The URL of the movie to download (required)|
 |`-d, --download_dir DOWNLOAD_DIR`|Specify a target download directory|
 |`-r RESOLUTION, --resolution RESOLUTION`|Target video resolution height. Use 0 to select the lowest. Default is the highest|
 |`-f FFMPEG, --ffmpeg FFMPEG`|ffmpeg directory|
@@ -43,3 +52,4 @@ You can customize the behavior of the script by passing different arguments when
 |`-c, --covers`|Download covers|
 |`-o, --overwrite`|Overwrite existing segments on the disk|
 |`-k, --keep`|Keep segments after download|
+|`-t, --threads`|Threads for concurrent downloads (default=10)|

--- a/aebn_dl.py
+++ b/aebn_dl.py
@@ -380,6 +380,22 @@ def worker(q):
         q.task_done()
 
 
+def convert_line_endings(file_path):
+    # replacement strings
+    WINDOWS_LINE_ENDING = b'\r\n'
+    UNIX_LINE_ENDING = b'\n'
+
+    with open(file_path, 'rb') as open_file:
+        content = open_file.read()
+
+    # Windows to Unix
+    if WINDOWS_LINE_ENDING in content:
+        content = content.replace(WINDOWS_LINE_ENDING, UNIX_LINE_ENDING)
+        with open(file_path, 'wb') as open_file:
+            open_file.write(content)
+        print('Converted list.txt to unix line endings, important for linux processing')
+
+
 if __name__ == "__main__":
     # Make Ctrl-C work when deamon threads are running
     signal.signal(signal.SIGINT, signal.SIG_DFL)
@@ -405,6 +421,8 @@ if __name__ == "__main__":
         download_movie(args.url)
     # if missing or invalid, check for a list.txt and download concurrently
     elif args.url == "list.txt":
+        if sys.platform == 'linux':
+            convert_line_endings("list.txt")  # important to have the proper newlines for linux
         file = open("list.txt")
         urllist = file.read().splitlines()  # remove the newlines
         file.close()


### PR DESCRIPTION
Feature for concurrent downloads. The maximum default threads is 10, but it can be set with -t/--threads. This has the same functionality as the bash script I shared on the (you know where) forum.