### PR TITLE
Added python3 command and clarified arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ pip3 install requests lxml tqdm
 2. Run the script with the desired movie URL:
 ```
 python aebn_dl.py https://*.aebn.com/*/movies/*
+or
+python3 aebn_dl.py https://*.aebn.com/*/movies/*
 ```
 
 3. The script will download the movie and save it in the current working directory.
@@ -35,11 +37,11 @@ You can customize the behavior of the script by passing different arguments when
 |`-h, --help`|Show this help message and exit|
 |`url`|The URL of the movie to download (required)|
 |`-d, --download_dir DOWNLOAD_DIR`|Specify a target download directory|
-|`-r RESOLUTION, --resolution RESOLUTION`|Target video resolution height. Use 0 to select the lowest. Default is the highest|
-|`-f FFMPEG, --ffmpeg FFMPEG`|ffmpeg directory|
-|`-sn SCENE, --scene SCENE`|Target scene to download|
+|`-r RESOLUTION, --resolution RESOLUTION`|Desired video resolution by pixel height. Use 0 to select the lowest available resolution. (default: highest available)|
+|`-f FFMPEG, --ffmpeg FFMPEG`|Specify the location of your ffmpeg directory|
+|`-sn SCENE, --scene SCENE`|Download a single scene using the relevant scene number on AEBN|
 |`-start SCENE_START, --scene_start SCENE_START`| Specify the start segment|
 |`-end SCENE_END, --scene_end SCENE_END`|Specify the end segment|
-|`-c, --covers`|Download covers|
-|`-o, --overwrite`|Overwrite existing segments on the disk|
-|`-k, --keep`|Keep segments after download|
+|`-c, --covers`|Download front and back covers|
+|`-o, --overwrite`|Overwrite existing audio and video segments if already present|
+|`-k, --keep`|Keep audio and video segments after download|

--- a/aebn_dl.py
+++ b/aebn_dl.py
@@ -34,7 +34,7 @@ If you have pip (normally installed with python), run this command in a terminal
 
 class Movie:
     def __init__(self, url, target_height=None, start_segment=None, end_segment=None, ffmpeg_dir=None, scene_n=None,
-                 download_covers=False, overwrite_existing_segmets=False, keep_segments_after_download=False, target_download_dir=None):
+                 download_covers=False, overwrite_existing_segments=False, keep_segments_after_download=False, target_download_dir=None):
 
         self.movie_url = url
         self.target_height = target_height
@@ -43,7 +43,7 @@ class Movie:
         self.ffmpeg_dir = ffmpeg_dir
         self.scene_n = scene_n
         self.download_covers = download_covers
-        self.overwrite_existing_segmets = overwrite_existing_segmets
+        self.overwrite_existing_segments = overwrite_existing_segments
         self.keep_segments_after_download = keep_segments_after_download
         self.target_download_dir = target_download_dir
         self.stream_types = ["a", "v"]
@@ -284,7 +284,7 @@ class Movie:
             segment_url = f"{self.base_stream_url}/{segment_type}_{stream_id}_{current_segment_number}.mp4d"
         segment_file_name = f"{segment_type}_{stream_id}_{current_segment_number}.mp4"
         segment_path = os.path.join(self.download_dir_path, segment_file_name)
-        if os.path.exists(segment_path) and not self.overwrite_existing_segmets:
+        if os.path.exists(segment_path) and not self.overwrite_existing_segments:
             # print(f"found {segment_file_name}")
             return True
         try:
@@ -354,14 +354,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("url", help="URL of the movie")
     parser.add_argument("-d", "--download_dir", type=str, help="Specify a download directory")
-    parser.add_argument("-r", "--resolution", type=int, default=1, help="Target video resolution height. Use 0 to select the lowest. Default is the highest")
-    parser.add_argument("-f", "--ffmpeg", type=str, help="ffmpeg directory")
-    parser.add_argument("-sn", "--scene", type=int, help="Target scene to download")
+    parser.add_argument("-r", "--resolution", type=int, default=1, help="Desired video resolution by pixel height. Use 0 to select the lowest available resolution. (default: highest available)")
+    parser.add_argument("-f", "--ffmpeg", type=str, help="Specify the location of your ffmpeg directory")
+    parser.add_argument("-sn", "--scene", type=int, help="Download a single scene using the relevant scene number on AEBN")
     parser.add_argument("-start", "--start_segment", type=int, help="Specify the start segment")
     parser.add_argument("-end", "--end_segment", type=int, help="Specify the end segment")
-    parser.add_argument("-c", "--covers", action="store_true", help="Download covers")
-    parser.add_argument("-o", "--overwrite", action="store_true", help="Overwrite existing segments on the disk")
-    parser.add_argument("-k", "--keep", action="store_true", help="Keep segments after download")
+    parser.add_argument("-c", "--covers", action="store_true", help="Download front and back covers")
+    parser.add_argument("-o", "--overwrite", action="store_true", help="Overwrite existing audio and video segments if already present")
+    parser.add_argument("-k", "--keep", action="store_true", help="Keep audio and video segments after downloading")
     args = parser.parse_args()
     movie_instance = Movie(
         url=args.url,
@@ -372,7 +372,7 @@ if __name__ == "__main__":
         start_segment=args.start_segment,
         end_segment=args.end_segment,
         download_covers=args.covers,
-        overwrite_existing_segmets=args.overwrite,
+        overwrite_existing_segments=args.overwrite,
         keep_segments_after_download=args.keep,
     )
     movie_instance.download()


### PR DESCRIPTION
Redo of #6 because I'm an idiot. (Hopefully did it right this time.)

Changes:

Added `python3` as an alternative for the command, since some Linux distros don't recognize `python` alone. Made some of the arguments' descriptions a little more clear, but feel free to change or ignore them if you think they're too verbose.

Also fixed the "segmet" typo.  <sup>Although now I kind of want to keep "segmet", since it makes me smile and adds some character to the script.</sup>