### PR TITLE
fix: add ageGated cookie to skip age check

### DIFF
--- a/aebn_dl/movie.py
+++ b/aebn_dl/movie.py
@@ -205,6 +205,10 @@ class Movie:
         retry_timeout = 3
         supported_methods = ['get', 'post']
 
+        if headers is None:
+            headers = {}
+        headers['Cookie'] = "ageGated="
+
         if request_type.lower() not in supported_methods:
             raise Exception("Invalid request type. Use 'get' or 'post'.")
         


### PR DESCRIPTION
# problem

This downloader currently does not work as it fails to retrieve the HTML page due to an age check that is present.

# solution

By adding a cookie `ageGated` to the request, the age check is skipped and the HTML page can be retrieved normally, and the downloader now works.