### PR TITLE
fix: bypass simple age check blocker with cookie

### DIFF
--- a/aebn_dl/movie_scraper.py
+++ b/aebn_dl/movie_scraper.py
@@ -23,6 +23,14 @@ class Movie:
         self.cover_url_front: str | None = None
         self.cover_url_back: str | None = None
         self.scenes_boundaries = []
+        for sex_pref_subdomain in ("straight", "gay"):
+            self._session.cookies.set(
+                name="ageGated",
+                value="true",
+                domain=f"{sex_pref_subdomain}.aebn.com",
+                path="/",
+                secure=True,
+            )
         self._scrape_info()
 
     def _scrape_info(self):
@@ -31,37 +39,58 @@ class Movie:
         content = html.fromstring(response.content)
 
         # Check for age verification page (Yoti)
-        if "dts-yoti-verification" in response.text or "Age Verification Required" in response.text:
-            raise RuntimeError("Age verification (Yoti) required. Your IP appears to be from a US state that requires age verification. Use a proxy from a different location with -p/--proxy option.")
+        if (
+            "dts-yoti-verification" in response.text
+            or "Age Verification Required" in response.text
+        ):
+            raise RuntimeError(
+                "Age verification (Yoti) required. Your IP appears to be from a US state that requires age verification. Use a proxy from a different location with -p/--proxy option."
+            )
 
         self.url_content_type = self.input_url.split("/")[3]
         self.movie_id = self.input_url.split("/")[5]
         self.studio_name = self._extract_studio_name(content)
-        self.title = content.xpath('//*[@class="dts-section-page-heading-title"]/h1/text()')[0].strip()
-        total_duration_string = content.xpath('//*[@class="section-detail-list-item-duration"][2]/text()')[0].strip()
+        self.title = content.xpath(
+            '//*[@class="dts-section-page-heading-title"]/h1/text()'
+        )[0].strip()
+        total_duration_string = content.xpath(
+            '//*[@class="section-detail-list-item-duration"][2]/text()'
+        )[0].strip()
         self.total_duration_seconds = utils.duration_to_seconds(total_duration_string)
         self.studio_name = utils.remove_chars(self.studio_name)
         self.title = utils.remove_chars(self.title)
-        self.performers = content.xpath('//section[contains(@class, "dts-section-page-detail-info-movie")]//div[@class="dts-detail-movie-stars"]//@title')
+        self.performers = content.xpath(
+            '//section[contains(@class, "dts-section-page-detail-info-movie")]//div[@class="dts-detail-movie-stars"]//@title'
+        )
         scene_elements = content.xpath('//section[@id[starts-with(., "scene")]]')
         for scene_element in scene_elements:
-            scene_performers = scene_element.xpath('.//div[@class="dts-detail-movie-stars"]//@title')
+            scene_performers = scene_element.xpath(
+                './/div[@class="dts-detail-movie-stars"]//@title'
+            )
             scene = Scene(performers=scene_performers)
             self.scenes.append(scene)
-        cover_front = content.xpath('//*[@class="dts-movie-boxcover-front"]//img/@src')[0].strip()
+        cover_front = content.xpath('//*[@class="dts-movie-boxcover-front"]//img/@src')[
+            0
+        ].strip()
         self.cover_url_front = "https:" + cover_front.split("?")[0]
-        cover_back = content.xpath('//*[@class="dts-movie-boxcover-background"]//img/@src')[0].strip()
+        cover_back = content.xpath(
+            '//*[@class="dts-movie-boxcover-background"]//img/@src'
+        )[0].strip()
         self.cover_url_back = "https:" + cover_back.split("?")[0]
 
     def _extract_studio_name(self, content) -> str:
-        studio_names = content.xpath('//*[@class="section-detail-list-item-studio"]/a/text()')
+        studio_names = content.xpath(
+            '//*[@class="section-detail-list-item-studio"]/a/text()'
+        )
         if len(studio_names) > 0:
             return studio_names[0].replace(",", "").strip()
         return ""
 
     def calculate_scenes_boundaries(self, segment_duration: float):
         """Calculate scene segment boundaries with data from m.aebn.net"""
-        response = self._session.get("https://m.aebn.net/movie/{}".format(self.movie_id))
+        response = self._session.get(
+            "https://m.aebn.net/movie/{}".format(self.movie_id)
+        )
         html_tree = html.fromstring(response.content)
         scene_elems = html_tree.xpath('//div[@class="scroller"]')
         if not scene_elems:
@@ -69,6 +98,12 @@ class Movie:
         for i, scene_el in enumerate(scene_elems):
             target_scene = self.scenes[i]
             target_scene.start_timing = int(scene_el.get("data-time-start"))
-            target_scene.end_timing = target_scene.start_timing + int(scene_el.get("data-time-duration"))
-            target_scene.start_segment = math.floor(int(target_scene.start_timing) / segment_duration)
-            target_scene.end_segment = math.ceil(int(target_scene.end_timing) / segment_duration) - 1
+            target_scene.end_timing = target_scene.start_timing + int(
+                scene_el.get("data-time-duration")
+            )
+            target_scene.start_segment = math.floor(
+                int(target_scene.start_timing) / segment_duration
+            )
+            target_scene.end_segment = (
+                math.ceil(int(target_scene.end_timing) / segment_duration) - 1
+            )


### PR DESCRIPTION
Apparently `aebn` implemented a simple age checker for all EU countries. It's not the Yoti one, just a "click this button to tell us you're 18+":

<img width="500" alt="image" src="https://github.com/user-attachments/assets/40e5cfc0-5c3f-453c-9fb6-668a476729e1" />

As it is now, [the downloader just throws an error and exits because it doesn't differentiate between the checkers](https://github.com/hyper440/aebn-vod-downloader/blob/74c8fc1d2cb9d5692d9b0b1e52d46385b887290c/aebn_dl/movie_scraper.py#L35). But this new one is very easy to bypass, it just needs a cookie added depending on the subdomain (or both, to cover both of them):

```json
[
	{
		"name": "ageGated",
		"value": "true",
		"domain": "<straight|gay>.aebn.com",
		"path": "/",
		"secure": true,
	}
]
```

So [I added them](https://github.com/jtabox/aebn-vod-downloader/blob/2607424465ad23dcd5dbf3270edf422b6093b334/aebn_dl/movie_scraper.py#L26).

PS. Noticed that some code formatting changed, it's because I've set VS Code to autoformat on save, haven't changed anything else than adding the cookies.