### PR TITLE
Fix scene processing, credential logging, and library initialization

### DIFF
--- a/aebn_dl/cli.py
+++ b/aebn_dl/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import signal
 from typing import Literal
 
 from . import Downloader
@@ -68,6 +69,8 @@ def log_error(future):
 
 
 def main():
+    # Make Ctrl-C work when threads are running
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
     parser = argparse.ArgumentParser()
     parser.add_argument("url", help="URL of the movie or list.txt")
     parser.add_argument("-o", "--output_dir", type=str, help="Specify the output directory")

--- a/aebn_dl/downloader.py
+++ b/aebn_dl/downloader.py
@@ -221,7 +221,10 @@ class Downloader:
         self.logger.info(f"Work dir: {self.work_dir}")
         self.logger.info("Target stream: {}".format(self.target_stream or "both"))
         if self.aggressive_segment_cleaning:
-            self.logger.info("Aggressive cleanup enabled, segments will be deleted before stream muxing")
+            if self.split_scenes:
+                self.logger.info("Aggressive cleanup enabled; segment deletion is deferred until all scenes complete")
+            else:
+                self.logger.info("Aggressive cleanup enabled, segments will be deleted before stream muxing")
         if self.target_height is None:
             self.logger.info("Target resolution: Highest")
         elif self.target_height > 0:
@@ -344,6 +347,7 @@ class Downloader:
                 files=scene_segments,
                 output_path=stream.path,
                 desc=f"{stream.human_name} scene segments",
+                delete_source_files=False,
             )
 
     def _filter_segments_for_scene(self, all_segments: list[str], scene) -> list[str]:
@@ -573,8 +577,10 @@ class Downloader:
         else:
             raise RuntimeError(f"Segment {segment_name} Download error! Response Status : {response.status_code}")
 
-    def _concat_segments(self, files: list[str], output_path: str, desc: str):
+    def _concat_segments(self, files: list[str], output_path: str, desc: str, delete_source_files: bool | None = None):
         """Concat segments into a single file"""
+        if delete_source_files is None:
+            delete_source_files = self.aggressive_segment_cleaning
         _files = [files[0], *sorted(files[1:], key=utils.natural_sort_key)]
         task = self.progress.add_task(description=f"Merging {desc}", total=len(_files))
         with open(output_path, "wb") as f:
@@ -584,6 +590,6 @@ class Downloader:
                     segment_file.close()
                     f.write(content)
                     self.progress.update(task, advance=1)
-                if self.aggressive_segment_cleaning:
+                if delete_source_files:
                     os.remove(segment_file_path)
         self.progress.update(task, visible=False)

--- a/aebn_dl/downloader.py
+++ b/aebn_dl/downloader.py
@@ -131,7 +131,9 @@ class Downloader:
         with context:
             self._initialize_download()
             scraped_movie = self._scrape_movie_info()
-            self._process_manifest(scraped_movie)
+            should_embed_metadata = not any((self.no_metadata, self.scene_n, self.start_segment, self.end_segment))
+            requires_scene_boundaries = bool(self.scene_n or self.split_scenes or should_embed_metadata)
+            self._process_manifest(scraped_movie, requires_scene_boundaries)
             self._create_dirs(scraped_movie.movie_id)
             self._set_stream_paths()
             if self.download_covers:
@@ -151,7 +153,6 @@ class Downloader:
                 output_path = os.path.join(self.output_dir, output_file_name)
                 self.logger.info(f"Output file name: {output_file_name}")
                 self._process_streams(output_path)
-                should_embed_metadata = not any((self.no_metadata, self.scene_n, self.start_segment, self.end_segment))
                 if should_embed_metadata:
                     self.logger.info("Embedding metadata")
                     utils.embed_metadata(output_path, scraped_movie)
@@ -163,7 +164,7 @@ class Downloader:
         """Print detailed movie info and scene segment boundaries."""
         self._initialize_download()
         movie = self._scrape_movie_info()
-        self._process_manifest(movie)
+        self._process_manifest(movie, requires_scene_boundaries=True)
 
         print(f"\n{movie.studio_name} - {movie.title}")
         print(f"Duration: {movie.total_duration_seconds // 60} min ({movie.total_duration_seconds}s)")
@@ -393,7 +394,7 @@ class Downloader:
         self.movie_work_dir = os.path.join(self.work_dir, movie_id)
         os.makedirs(self.movie_work_dir, exist_ok=True)
 
-    def _process_manifest(self, scraped_movie: Movie) -> None:
+    def _process_manifest(self, scraped_movie: Movie, requires_scene_boundaries: bool) -> None:
         """Processes the movie manifest."""
         self.logger.info("Processing manifest")
         self.manifest = Manifest(
@@ -404,7 +405,8 @@ class Downloader:
             force_resolution=self.force_resolution,
         )
         self.manifest.process_manifest()
-        scraped_movie.calculate_scenes_boundaries(self.manifest.segment_duration)
+        if requires_scene_boundaries:
+            scraped_movie.calculate_scenes_boundaries(self.manifest.segment_duration)
 
     def _scrape_movie_info(self) -> Movie:
         """Scrapes movie information from the input URL."""

--- a/aebn_dl/downloader.py
+++ b/aebn_dl/downloader.py
@@ -213,7 +213,8 @@ class Downloader:
     def _log_init_state(self) -> None:
         """Log input arguments"""
         self.logger.info(f"Input URL: {self.input_url}")
-        self.logger.info(f"Proxy: {self.proxy}")
+        proxy_state = "configured" if self.proxy else "disabled"
+        self.logger.info(f"Proxy: {proxy_state}")
         self.logger.info(f"Threads: {self.threads}")
         self.logger.info(f"Output dir: {self.output_dir}")
         self.logger.info(f"Work dir: {self.work_dir}")

--- a/aebn_dl/downloader.py
+++ b/aebn_dl/downloader.py
@@ -4,7 +4,6 @@ import datetime
 import email.utils as eut
 import logging
 import os
-import signal
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import nullcontext
@@ -29,9 +28,6 @@ from .exceptions import Forbidden
 from .manifest_parser import Manifest
 from .models import MediaStream
 from .movie_scraper import Movie
-
-# Make Ctrl-C work when threads are running
-signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 
 class Downloader:

--- a/aebn_dl/movie_scraper.py
+++ b/aebn_dl/movie_scraper.py
@@ -74,6 +74,8 @@ class Movie:
         scene_elems = html_tree.xpath('//div[@class="scroller"]')
         if not scene_elems:
             raise RuntimeError("Failed to scrape scene data")
+        if len(scene_elems) != len(self.scenes):
+            raise RuntimeError(f"Scene count mismatch: mobile={len(scene_elems)}, movie={len(self.scenes)}")
         for i, scene_el in enumerate(scene_elems):
             target_scene = self.scenes[i]
             target_scene.start_timing = int(scene_el.get("data-time-start"))

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "aebndl"
-version = "0.8.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi", version = "0.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -130,8 +130,8 @@ resolution-markers = [
     "python_full_version < '3.9'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.9'" },
-    { name = "cffi", marker = "python_full_version < '3.9'" },
+    { name = "certifi" },
+    { name = "cffi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9f/7d/c326faf5a772a11011dcc30aca5b64c197bcf59fdd9b90bf28b700d6d682/curl_cffi-0.9.0.tar.gz", hash = "sha256:4818e074b61cb209bd8d4d0d03783313d4773e6b51f8b815e25aad9cc146a7b7", size = 144117, upload-time = "2025-02-15T11:48:30.643Z" }
 wheels = [
@@ -154,8 +154,8 @@ resolution-markers = [
     "python_full_version >= '3.9'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.9'" },
-    { name = "cffi", marker = "python_full_version >= '3.9'" },
+    { name = "certifi" },
+    { name = "cffi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/c9/014d52df55ccb1d21645aee6f104fe1031c575eb64ffe4392419b4c7da49/curl_cffi-0.11.3.tar.gz", hash = "sha256:0b21f39980bce3fb5aeea8d64d76bd465825c54a45e2933ca4df5ec0f041ba49", size = 149152, upload-time = "2025-06-09T03:06:43.321Z" }
 wheels = [


### PR DESCRIPTION
## What this PR fixes

This PR cleans up several edge cases that could make downloads fail unexpectedly or expose sensitive proxy details.

### Safer proxy logging

Proxy URLs can contain usernames and passwords. The downloader now logs only whether a proxy is configured, without writing the URL itself to the console or log file.

### More reliable scene downloads

- Scene-boundary data is fetched only when a feature actually needs it, so normal no-metadata and partial downloads no longer depend on the separate scene endpoint.
- If the main and mobile pages report different scene counts, the downloader now stops with a clear error before partially updating scene data.
- With `--split-scenes` and aggressive cleanup enabled, shared segments are kept until every scene has been created. Cleanup still happens afterward.

### Safer library imports

Importing `aebn_dl` no longer changes the process-wide SIGINT handler. The Ctrl-C setup now happens only when the CLI starts, so the package can be safely imported from worker threads or other applications.

### Updated lockfile

`uv.lock` now matches the `0.10.0` version in `pyproject.toml`, and the lockfile consistency check passes again.

## Validation

- `ruff check .`
- worker-thread import smoke check
- `uv lock --check`
- manual review of each commit and the combined diff

No regression tests were added or run, following the repository instructions.
