### PR TITLE
Fix AEBN age-gate cookie domains

### DIFF
--- a/aebn_dl/movie_scraper.py
+++ b/aebn_dl/movie_scraper.py
@@ -23,11 +23,11 @@ class Movie:
         self.cover_url_front: str | None = None
         self.cover_url_back: str | None = None
         self.scenes_boundaries = []
-        for sex_pref_subdomain in ("straight", "gay"):
+        for cookie_domain in ("straight.aebn.com", "gay.aebn.com", "m.aebn.net", "vod.aebn.com"):
             self._session.cookies.set(
                 name="ageGated",
                 value="true",
-                domain=f"{sex_pref_subdomain}.aebn.com",
+                domain=cookie_domain,
                 path="/",
                 secure=True,
             )


### PR DESCRIPTION
## Summary

- send the `ageGated=true` cookie to the mobile scene metadata endpoint
- send the same cookie to `vod.aebn.com`
- preserve cookie handling for the straight and gay sites

## Root cause

The cookie was scoped only to `straight.aebn.com` and `gay.aebn.com`. Requests to `m.aebn.net` therefore returned the age-confirmation page instead of scene timing markup, causing `Failed to scrape scene data`.

## Impact

Movie URLs can retrieve scene boundaries again, including through the VOD hostname.

## Validation

- compiled `aebn_dl/movie_scraper.py` with `py_compile`
- ran a live `--info` smoke check for the straight URL and retrieved all four scenes
- ran a live `--info` smoke check for the VOD URL and retrieved all four scenes
- regression tests were not run per repository instructions
